### PR TITLE
Try to fix #33 InaccessibleObjectException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.5</version>
+			<version>2.9.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.miglayout</groupId>

--- a/src/main/resources/amidst/metadata.properties
+++ b/src/main/resources/amidst/metadata.properties
@@ -1,7 +1,7 @@
 project.build.sourceEncoding=UTF-8
 amidst.build.jdk.version=1.8
-amidst.build.filename=amidst-minetest-v1-4-1
+amidst.build.filename=amidst-minetest-v1-4-2
 
 amidst.version.major=1
 amidst.version.minor=4
-amidst.version.preReleaseSuffix=1
+amidst.version.preReleaseSuffix=2


### PR DESCRIPTION
Upgrade Gson to avoid
[crash] Amidst has encounted an uncaught exception on the thread Thread[AWT-EventQueue-0,6,main] [crash] java.lang.reflect.InaccessibleObjectException: Unable to make field int java.awt.Color.value accessible: module java.desktop does not "opens java.awt" to unnamed module @3bf44630

This change can be tested via the following builds:
* https://github.com/Treer/Amidst-for-Minetest/releases/download/v1.4-2/amidst-minetest-v1-4-2.jar
* https://github.com/Treer/Amidst-for-Minetest/releases/download/v1.4-2/amidst-minetest-v1-4-2.exe
